### PR TITLE
Mkdocs setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,94 @@
-# cloud-service
+# Lounastutka
 
-## MKDOCS
+Lounastutka is a containerized full-stack application.
 
-Project documentation is made using markdown language and with the `mkdocs` utility.
+- Frontend: React Router app in Frontend
+- Backend: Bun service in Backend
+- Database: PostgreSQL
 
-Install `mkdocs` [getting started](https://www.mkdocs.org/getting-started/).
+The repository supports two ways to run the app:
 
-Build the documentation:
+- Local development with Docker Compose
+- Production-style deployment with Docker Swarm and Traefik
 
+## Quick Start
+
+Run locally from repository root:
+
+```bash
+docker compose -f compose.dev.yaml up
 ```
-mkdocs build
+
+Available endpoints:
+
+- Frontend: http://localhost:5173
+- Backend: http://localhost:3001
+- PostgreSQL: localhost:5432
+
+Stop local services:
+
+```bash
+docker compose -f compose.dev.yaml down
 ```
 
-Or serve locally in a browser:
+Remove local volumes too:
 
+```bash
+docker compose -f compose.dev.yaml down -v
 ```
+
+## Swarm Deployment
+
+Initialize Swarm (once):
+
+```bash
+docker swarm init
+```
+
+Build images:
+
+```bash
+docker build -t lounastutka-backend:latest ./Backend
+docker build -t lounastutka-frontend:latest ./Frontend
+```
+
+Deploy stack:
+
+```bash
+docker stack deploy -c compose.yaml lounastutka
+```
+
+Useful checks:
+
+```bash
+docker stack services lounastutka
+docker service ps lounastutka_app
+docker service ps lounastutka_frontend
+```
+
+Main Swarm endpoints:
+
+- App via Traefik: http://localhost
+- Traefik dashboard: http://localhost:8080
+- Grafana: http://localhost:3000
+
+## Documentation
+
+Project docs are built with MkDocs.
+
+Serve docs locally:
+
+```bash
 mkdocs serve
 ```
 
+Build static docs:
 
+```bash
+mkdocs build
+```
+
+See also:
+
+- docs/installation.md
+- docker-instructions.md

--- a/docs/backend/index.md
+++ b/docs/backend/index.md
@@ -1,0 +1,1 @@
+../../Backend/README.md

--- a/docs/frontend/index.md
+++ b/docs/frontend/index.md
@@ -1,0 +1,1 @@
+../../Frontend/README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,23 +1,47 @@
-# Welcome to MkDocs
+# Lounastutka HEIEIIE
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+Lounastutka is a containerized full-stack app with:
 
-## Commands
+- Frontend: React Router app
+- Backend: Bun HTTP service
+- Database: PostgreSQL
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+The repository includes two deployment modes:
 
-## Project layout
+- Local development with Docker Compose
+- Production-style Docker Swarm stack with Traefik and monitoring services
 
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+## Services Overview
 
+Development (`compose.dev.yaml`):
 
+- Frontend: `http://localhost:5173`
+- Backend: `http://localhost:3001`
+- PostgreSQL: `localhost:5432`
 
-## Test addition
+Swarm (`compose.yaml`):
 
-This section exists as a means to test the documentation and should not be left as is to the final version.
+- Traefik edge router: `http://localhost`
+- Traefik dashboard: `http://localhost:8080`
+- Grafana: `http://localhost:3000`
+- Prometheus and Loki are internal by default
+
+## Documentation Map
+
+- Installation and run instructions: [Installation](installation.md)
+- Frontend module notes: [Frontend](frontend/index.md)
+- Backend module notes: [Backend](backend/index.md)
+
+## Build Documentation
+
+From repository root:
+
+```bash
+mkdocs build
+```
+
+Serve locally with live reload:
+
+```bash
+mkdocs serve
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Lounastutka HEIEIIE
+# Lounastutka
 
 Lounastutka is a containerized full-stack app with:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,15 +1,96 @@
 # Installation
 
-## Local setup
+This guide reflects the current setup of the repository.
 
-This documentation describes the processes needed to get the local version of the system running and accessible on local network. 
+## Prerequisites
 
-## Dependencies:
+- Docker Engine
+- Docker Compose plugin (`docker compose`)
+- Optional for docs: Python and MkDocs
 
-* Bunny (bun.js)
-* PostgreSQL
-* Docker
-* Docker-compose
-* Python 3.14 or newer
+## Quick Start (Local Development)
 
+Run from repository root:
 
+```bash
+docker compose -f compose.dev.yaml up
+```
+
+This starts:
+
+- Frontend on `http://localhost:5173`
+- Backend on `http://localhost:3001`
+- PostgreSQL on `localhost:5432`
+
+Stop services:
+
+```bash
+docker compose -f compose.dev.yaml down
+```
+
+Stop and remove volumes:
+
+```bash
+docker compose -f compose.dev.yaml down -v
+```
+
+## Production-Style Swarm Deployment
+
+Initialize Swarm (once):
+
+```bash
+docker swarm init
+```
+
+Build images:
+
+```bash
+docker build -t lounastutka-backend:latest ./Backend
+docker build -t lounastutka-frontend:latest ./Frontend
+```
+
+Deploy stack:
+
+```bash
+docker stack deploy -c compose.yaml lounastutka
+```
+
+Useful checks:
+
+```bash
+docker stack services lounastutka
+docker service ps lounastutka_app
+docker service ps lounastutka_frontend
+```
+
+Swarm endpoints:
+
+- App (via Traefik): `http://localhost`
+- Traefik dashboard: `http://localhost:8080`
+- Grafana: `http://localhost:3000`
+
+Remove stack:
+
+```bash
+docker stack rm lounastutka
+```
+
+## Notes
+
+- In local development, frontend and backend source folders are bind-mounted into containers.
+- Prometheus and Loki are included in Swarm mode and are internal by default.
+- For real production, move credentials from Compose files into a secret manager.
+
+## Documentation Commands
+
+Build docs:
+
+```bash
+mkdocs build
+```
+
+Serve docs locally:
+
+```bash
+mkdocs serve
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,1 +1,14 @@
 site_name: Lounastutka Documentation
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Frontend: frontend/index.md
+  - Backend: backend/index.md
+
+watch:
+  - mkdocs.yml
+  - Backend/README.md
+  - Frontend/README.md
+  - docs/
+theme: readthedocs


### PR DESCRIPTION
This pull request significantly improves the documentation for the Lounastutka project, making it clearer, more structured, and tailored to the actual application stack and deployment methods. The main README and documentation files have been rewritten to describe the full-stack architecture, local and Swarm deployment, and usage of Docker and MkDocs. The MkDocs configuration and navigation have also been updated for a more organized documentation experience.

**Documentation Overhaul and Structure:**

* Rewrote `README.md` to describe the Lounastutka app, its architecture (React frontend, Bun backend, PostgreSQL), and detailed instructions for both local Docker Compose development and Docker Swarm production-style deployment, including endpoints and useful commands.
* Replaced the default `docs/index.md` with a project-specific overview, including service endpoints for both development and Swarm, a documentation map, and build instructions for the docs.
* Updated `docs/installation.md` to provide step-by-step installation and deployment instructions, prerequisites, and notes for both local and Swarm setups, as well as documentation commands.

**MkDocs Configuration Improvements:**

* Enhanced `mkdocs.yml` to define a clear navigation structure (Home, Installation, Frontend, Backend), set the theme, and specify files/folders to watch for live reload.

**Module Documentation Linking:**

* Added references to the frontend and backend module READMEs in `docs/frontend/index.md` and `docs/backend/index.md` to integrate module-level documentation into the MkDocs site. [[1]](diffhunk://#diff-4f891f1b26e2da32d122777fffcdf083da3bee019c0e5ec1ada10618e534eb91R1) [[2]](diffhunk://#diff-1715555730e08d7fdadbbfa4afe65143336a430664a6ab3b1e7f9588c713a52aR1)

This should fix #16 