### PR TITLE
Local dev Traefik setup

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,6 +1,82 @@
 services:
+  traefik:
+    image: traefik:v3.6
+    container_name: traefik
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    
+    networks:
+      # Connect to the 'traefik_proxy' overlay network for inter-container communication across nodes
+      - proxy
+
+    ports:
+      - "80:80"
+      - "443:443"
+    
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./certs:/certs:ro
+      - ./dynamic:/dynamic:ro
+
+    command:
+      # EntryPoints
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.websecure.http.tls=true"
+
+      # Attach the static configuration tls.yaml file that contains the tls configuration settings
+      - "--providers.file.filename=/dynamic/tls.yaml"
+
+      # Providers 
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=proxy"
+
+      # API & Dashboard 
+      - "--api.dashboard=true"
+      - "--api.insecure=false"
+
+      # Observability 
+      - "--log.level=INFO"
+      - "--accesslog=true"
+      - "--metrics.prometheus=true"
+
+    # Traefik Dynamic configuration via Docker labels
+    labels:
+      # Enable self‑routing
+      - "traefik.enable=true"
+
+      # Dashboard router
+      - "traefik.http.routers.dashboard.rule=Host(`dashboard.docker.localhost`)"
+      - "traefik.http.routers.dashboard.entrypoints=websecure"
+      - "traefik.http.routers.dashboard.service=api@internal"
+      - "traefik.http.routers.dashboard.tls=true"
+
+      # Basic‑auth middleware
+      - "traefik.http.middlewares.dashboard-auth.basicauth.users=admin:$$apr1$$zcBUgvAR$$482EWeJ0xk2wquAJdYDNG/"
+      - "traefik.http.routers.dashboard.middlewares=dashboard-auth@docker"
+
+  # Whoami application
+  whoami:
+    image: traefik/whoami
+    container_name: whoami
+    restart: unless-stopped
+    networks:
+      - proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.whoami.rule=Host(`whoami.docker.localhost`)"
+      - "traefik.http.routers.whoami.entrypoints=websecure"
+      - "traefik.http.routers.whoami.tls=true"
+
   backend:
     image: oven/bun:1
+    networks:
+      - proxy
     working_dir: /app
     command: sh -lc "bun install && bun --watch index.ts"
     volumes:
@@ -11,9 +87,16 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.backend.rule=Host(`localhost`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.backend.entrypoints=websecure"
+      - "traefik.http.routers.backend.tls=true"
 
   frontend:
     image: oven/bun:1
+    networks:
+      - proxy
     working_dir: /app
     command: sh -lc "bun install && bun run dev --host 0.0.0.0"
     volumes:
@@ -23,6 +106,11 @@ services:
       - "5173:5173"
     depends_on:
       - backend
+    labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.frontend.rule=Host(`localhost`)"
+    - "traefik.http.routers.frontend.entrypoints=websecure"
+    - "traefik.http.routers.frontend.tls=true"
 
   db:
     image: postgres:16-alpine
@@ -44,3 +132,7 @@ volumes:
   backend_node_modules:
   frontend_node_modules:
   pg_data_dev:
+
+networks:
+  proxy:
+    name: proxy


### PR DESCRIPTION
This pull request introduces Traefik as a reverse proxy and ingress controller in the `compose.dev.yaml` Docker Compose configuration. The main goal is to enable secure HTTPS routing to the application services (backend, frontend, and a demo whoami service) through a shared `proxy` network, with Traefik handling TLS termination, routing, and observability features. All relevant services are updated to connect to the new proxy network and are configured with appropriate Traefik labels for routing.

**Traefik integration and configuration:**

* Added a new `traefik` service with extensive configuration for HTTPS (TLS), automatic HTTP-to-HTTPS redirection, Docker provider integration, dashboard access (with basic authentication), logging, and Prometheus metrics. The service mounts necessary volumes and exposes ports 80 and 443.
* Created a dedicated `proxy` network for inter-service communication and configured Traefik and all routed services to use this network. [[1]](diffhunk://#diff-792f487c5129f06591788bf33833211e3acbde5b9164658a2c303cdc881e9d4fR2-R79) [[2]](diffhunk://#diff-792f487c5129f06591788bf33833211e3acbde5b9164658a2c303cdc881e9d4fR135-R138)

**Service exposure and routing:**

* Added a demo `whoami` service for testing Traefik routing, with labels to expose it at `whoami.docker.localhost` over HTTPS.
* Updated the `backend` service to join the `proxy` network and added Traefik labels to expose its API at `localhost` under the `/api` path, secured via HTTPS. [[1]](diffhunk://#diff-792f487c5129f06591788bf33833211e3acbde5b9164658a2c303cdc881e9d4fR2-R79) [[2]](diffhunk://#diff-792f487c5129f06591788bf33833211e3acbde5b9164658a2c303cdc881e9d4fR90-R99)
* Updated the `frontend` service to join the `proxy` network and added Traefik labels to expose it at `localhost` over HTTPS. [[1]](diffhunk://#diff-792f487c5129f06591788bf33833211e3acbde5b9164658a2c303cdc881e9d4fR2-R79) [[2]](diffhunk://#diff-792f487c5129f06591788bf33833211e3acbde5b9164658a2c303cdc881e9d4fR109-R113)

**Networking and organization:**

* Defined the `proxy` network at the bottom of the file to ensure all relevant services and Traefik are connected for proper routing.