### PR TITLE
Add Promtail service and configuration for logging

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -249,6 +249,21 @@ services:
           - node.role == manager
 
   # ---------------------------------------------
+  # Logging: Promtail
+  # ---------------------------------------------
+  promtail:
+  image: grafana/promtail:latest
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+    - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    - ./docker/promtail/config.yaml:/etc/promtail/config.yaml:ro
+  command: -config.file=/etc/promtail/config.yaml
+  networks:
+    - monitoring
+  deploy:
+    mode: global  # run on every Swarm node
+
+  # ---------------------------------------------
   # Visualization: Grafana
   # ---------------------------------------------
   grafana:

--- a/docker/promtail/config.yaml
+++ b/docker/promtail/config.yaml
@@ -1,0 +1,19 @@
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: [__meta_docker_container_name]
+        target_label: container
+      - source_labels: [__meta_docker_container_log_stream]
+        target_label: streams


### PR DESCRIPTION
This pull request introduces centralized logging to the stack by adding Promtail as a service for log collection and forwarding. The main changes involve updating the Docker Compose configuration and adding a Promtail configuration file.

**Logging integration:**

* Added a new `promtail` service to `compose.yaml` to collect logs from all Docker containers and forward them to Loki; configured to run globally on all Swarm nodes and connected to the `monitoring` network.
* Added a new Promtail configuration file at `docker/promtail/config.yaml` specifying the server port, log positions file, Loki client endpoint, and scrape configuration for Docker containers.